### PR TITLE
Add support for new Paper Brigadier Command Support

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -23,6 +23,9 @@
             <option value="$PROJECT_DIR$/bmm-core" />
             <option value="$PROJECT_DIR$/bmm-fabric" />
             <option value="$PROJECT_DIR$/bmm-paper" />
+            <option value="$PROJECT_DIR$/bmm-paper/src" />
+            <option value="$PROJECT_DIR$/bmm-paper/src/main" />
+            <option value="$PROJECT_DIR$/bmm-paper/src/main/java" />
             <option value="$PROJECT_DIR$/buildSrc" />
             <option value="$PROJECT_DIR$/kpaper-light" />
           </set>

--- a/bmm-paper/src/main/java/bmm/BMMPluginBootstrap.java
+++ b/bmm-paper/src/main/java/bmm/BMMPluginBootstrap.java
@@ -1,0 +1,20 @@
+package de.miraculixx.bmm;
+
+import io.papermc.paper.plugin.bootstrap.PluginBootstrap;
+import io.papermc.paper.plugin.bootstrap.BootstrapContext;
+import io.papermc.paper.plugin.bootstrap.PluginProviderContext;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+
+public class BMMPluginBootstrap implements PluginBootstrap {
+
+    @Override
+    public void bootstrap(@NotNull BootstrapContext context) {
+
+    }
+
+    @Override
+    public @NotNull JavaPlugin createPlugin(@NotNull PluginProviderContext context) {
+        return new BMMarker();
+    }
+}

--- a/bmm-paper/src/main/java/bmm/BMMPluginLoader.java
+++ b/bmm-paper/src/main/java/bmm/BMMPluginLoader.java
@@ -1,0 +1,36 @@
+package de.miraculixx.bmm;
+
+import io.papermc.paper.plugin.loader.PluginClasspathBuilder;
+import io.papermc.paper.plugin.loader.PluginLoader;
+import io.papermc.paper.plugin.loader.library.impl.MavenLibraryResolver;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.stream.Stream;
+
+public class BMMPluginLoader implements PluginLoader {
+    private static final RemoteRepository MAVEN_CENTRAL = new RemoteRepository.Builder("central", "default", "https://repo.maven.apache.org/maven2").build();
+    private static final RemoteRepository MAVEN_SNAPSHOT = new RemoteRepository.Builder("snapshot", "default", "https://s01.oss.sonatype.org/content/repositories/snapshots").build();
+
+    @Override
+    public void classloader(@NotNull PluginClasspathBuilder classpathBuilder) {
+
+        MavenLibraryResolver resolver = new MavenLibraryResolver();
+        resolver.addRepository(MAVEN_CENTRAL);
+        resolver.addRepository(MAVEN_SNAPSHOT);
+
+        Stream.of(
+                "org.jetbrains.kotlin:kotlin-stdlib:1.9.23",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4",
+                "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1",
+                "dev.jorel:commandapi-bukkit-shade-mojang-mapped:9.5.0-SNAPSHOT"
+            )
+            .map(artifact -> new Dependency(new DefaultArtifact(artifact), null))
+            .forEach(resolver::addDependency);
+
+        classpathBuilder.addLibrary(resolver);
+    }
+}

--- a/bmm-paper/src/main/kotlin/de/miraculixx/bmm/BMMarker.kt
+++ b/bmm-paper/src/main/kotlin/de/miraculixx/bmm/BMMarker.kt
@@ -22,11 +22,11 @@ class BMMarker : JavaPlugin() {
         consoleAudience = server.consoleSender
 
         // Load Content
-        CommandAPI.onLoad(CommandAPIBukkitConfig(this).silentLogs(true).useMojangMappings(true))
+        CommandAPI.onLoad(CommandAPIBukkitConfig(this).silentLogs(true))
         MarkerCommand()
 
         // BlueMap Management
-        blueMapInstance = BlueMap(dataFolder, description.version.toIntOrNull() ?: 0)
+        blueMapInstance = BlueMap(dataFolder, pluginMeta.version.toIntOrNull() ?: 0)
     }
 
     override fun onEnable() {

--- a/bmm-paper/src/main/resources/paper-plugin.yml
+++ b/bmm-paper/src/main/resources/paper-plugin.yml
@@ -1,0 +1,11 @@
+name: BlueMap-Marker
+version: '164'
+main: de.miraculixx.bmm.BMMarker
+description: A BlueMap addition plugin. Give your players the option to place markers on the map
+api-version: '1.20'
+bootstrapper: de.miraculixx.bmm.BMMPluginBootstrap
+loader: de.miraculixx.bmm.BMMPluginLoader
+dependencies:
+  server:
+    BlueMap:
+      load: BEFORE

--- a/bmm-paper/src/main/resources/plugin.yml
+++ b/bmm-paper/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ description: "A BlueMap addition plugin. Give your players the option to place m
 author: Miraculixx
 website: https://mutils.net
 load: STARTUP
-api-version: 1.16
+api-version: 1.20
 depend:
   - "BlueMap"
 libraries:
@@ -13,4 +13,4 @@ libraries:
   - "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
   - "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4"
   - "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
-  - "dev.jorel:commandapi-bukkit-shade-mojang-mapped:9.4.0"
+  - "dev.jorel:commandapi-bukkit-shade-mojang-mapped:9.5.0-SNAPSHOT"

--- a/buildSrc/src/main/kotlin/paper-script.gradle.kts
+++ b/buildSrc/src/main/kotlin/paper-script.gradle.kts
@@ -15,6 +15,7 @@ repositories {
     }
 
     maven("https://repo.papermc.io/repository/maven-public/")
+    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
 }
 
 paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArtifactConfiguration.MOJANG_PRODUCTION
@@ -22,8 +23,8 @@ paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArt
 dependencies {
     paperweight.paperDevBundle("${minecraftVersion}-R0.1-SNAPSHOT")
     implementation("com.github.BlueMap-Minecraft:BlueMapAPI:v2.7.0")
-    implementation("dev.jorel:commandapi-bukkit-shade-mojang-mapped:9.4.0")
-    compileOnly("dev.jorel:commandapi-bukkit-kotlin:9.4.0")
+    implementation("dev.jorel:commandapi-bukkit-shade-mojang-mapped:9.5.0-SNAPSHOT")
+    compileOnly("dev.jorel:commandapi-bukkit-kotlin:9.5.0-SNAPSHOT")
 }
 
 tasks {


### PR DESCRIPTION
For that, changing to the Snapchat Version of CommandAPI was required. Only PaperPlugins support custom Maven Repos. Related to https://github.com/JorelAli/CommandAPI/issues/554. Fixes #26.